### PR TITLE
Fix(incidents): Handle null start_time in update_incidents command

### DIFF
--- a/incidents/sources/tflapiv1.py
+++ b/incidents/sources/tflapiv1.py
@@ -68,7 +68,7 @@ def check():
                         if created:
                             if issue["appearance"] == "PlannedWork":
                                 start_date, end_date = find_dates(status_details)
-                                report.start_time = start_date
+                                report.start_time = start_date or timezone.now()
                                 report.end_time = end_date
                                 if " changes " not in status_details:
                                     if (start_date and start_date < timezone.now()) or (

--- a/incidents/tests.py
+++ b/incidents/tests.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+from django.utils import timezone
+from .utils import find_dates
+from .sources.tflapiv1 import check
+from .models import Report
+from unittest.mock import patch
+
+class FindDatesTest(TestCase):
+    def test_parse_multi_date(self):
+        text = "Tuesday 21, Wednesday 22 and Thursday 23 October"
+        start_date, end_date = find_dates(text)
+        self.assertEqual(start_date.day, 21)
+        self.assertEqual(start_date.month, 10)
+        self.assertEqual(end_date.day, 23)
+        self.assertEqual(end_date.month, 10)
+
+    def test_parse_fail(self):
+        text = "Some random text"
+        start_date, end_date = find_dates(text)
+        self.assertIsNone(start_date)
+        self.assertIsNone(end_date)
+
+class TflApiV1Test(TestCase):
+    @patch('incidents.sources.tflapiv1.requests.get')
+    def test_fallback_to_now(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.text = '''
+            [{
+                "description": "Some disruption with no step free access",
+                "atcoCode": "123",
+                "appearance": "PlannedWork",
+                "additionalInformation": ""
+            }]
+        '''
+        with patch('incidents.sources.tflapiv1.find_station_from_naptan') as mock_find_station:
+            mock_find_station.return_value = True
+            check()
+            report = Report.objects.first()
+            self.assertIsNotNone(report.start_time)
+            self.assertTrue((timezone.now() - report.start_time).total_seconds() < 1)

--- a/incidents/utils.py
+++ b/incidents/utils.py
@@ -88,6 +88,7 @@ def parse_date(text):
 
 def find_dates(text):
     start_and_end = re.search("From (.*?) until (.*?)(,|there|due)", text, flags=re.I)
+    multi_date = re.search(r"(\w+ \d+), .*? and (\w+ \d+ \w+)", text, flags=re.I)
 
     start_date = None
     end_date = None
@@ -96,11 +97,15 @@ def find_dates(text):
         start_date = parse_date(start_and_end.groups()[0])
         end_date = parse_date(start_and_end.groups()[1])
 
-        while start_date and end_date and end_date < start_date:
-            start_date = start_date.replace(year=start_date.year - 1)
+    elif multi_date:
+        start_date = parse_date(multi_date.groups()[0])
+        end_date = parse_date(multi_date.groups()[1])
 
-        if start_date and end_date and start_date.year == 2:
-            start_date = start_date.replace(year=end_date.year, month=end_date.month)
+    while start_date and end_date and end_date < start_date:
+        start_date = start_date.replace(year=start_date.year - 1)
+
+    if start_date and end_date and start_date.year == 2:
+        start_date = start_date.replace(year=end_date.year, month=end_date.month)
 
     return start_date, end_date
 


### PR DESCRIPTION
This commit resolves a `CommandError` in the `update_incidents` command that occurred when a null value was inserted into the `start_time` column.

The `find_dates` utility has been updated to correctly parse multi-day date formats (e.g., "Tuesday 21, Wednesday 22 and Thursday 23 October").

Additionally, the `check_tflv1` function now uses `timezone.now()` as a fallback for `start_time` when date parsing fails, ensuring the `start_time` is always populated.

Unit tests have been added to verify both the new date parsing logic and the fallback mechanism.

Note: The existing test suite could not be run in the development environment due to an incompatibility between the project's migrations and the SQLite database backend used for testing. The new tests were verified using a standalone test script.